### PR TITLE
update url for Deep Learning with PyTorch: A 60-minute Blitz

### DIFF
--- a/char-rnn-classification/char-rnn-classification.ipynb
+++ b/char-rnn-classification/char-rnn-classification.ipynb
@@ -34,7 +34,7 @@
     "I assume you have at least installed PyTorch, know Python, and understand Tensors:\n",
     "\n",
     "* http://pytorch.org/ For installation instructions\n",
-    "* [Deep Learning with PyTorch: A 60-minute Blitz](https://github.com/pytorch/tutorials/blob/master/Deep%20Learning%20with%20PyTorch.ipynb) to get started with PyTorch in general\n",
+    "* [Deep Learning with PyTorch: A 60-minute Blitz](http://pytorch.org/tutorials/beginner/deep_learning_60min_blitz.html\n",
     "* [jcjohnson's PyTorch examples](https://github.com/jcjohnson/pytorch-examples) for an in depth overview\n",
     "* [Introduction to PyTorch for former Torchies](https://github.com/pytorch/tutorials/blob/master/Introduction%20to%20PyTorch%20for%20former%20Torchies.ipynb) if you are former Lua Torch user\n",
     "\n",


### PR DESCRIPTION
Previous url for Deep Learning with PyTorch: A 60-minute Blitz is no longer valid. Suggest update to http://pytorch.org/tutorials/beginner/deep_learning_60min_blitz.html.