### PR TITLE
Fixes error of #22, #15 in Jupyter Notebook

### DIFF
--- a/char-rnn-generation/char-rnn-generation.ipynb
+++ b/char-rnn-generation/char-rnn-generation.ipynb
@@ -341,7 +341,7 @@
     "\n",
     "    for c in range(chunk_len):\n",
     "        output, hidden = decoder(inp[c], hidden)\n",
-    "        loss += criterion(output.view(-1), target[c])\n",
+    "        loss += criterion(output, target[c])\n",
     "\n",
     "    loss.backward()\n",
     "    decoder_optimizer.step()\n",


### PR DESCRIPTION
This commit is similar to spro/practical-pytorch@f5916ffe461098527c763048a9b11519eab342b9

As mentioned, the `output` part is re-factored to reflect the changes of the above commit, into the Jupyter Notebook as well.