### PR TITLE
fix UnicodeDecodeError failing on Spanish name Álvarez

### DIFF
--- a/char-rnn-classification/data.py
+++ b/char-rnn-classification/data.py
@@ -18,7 +18,7 @@ def unicodeToAscii(s):
 
 # Read a file and split into lines
 def readLines(filename):
-    lines = open(filename).read().strip().split('\n')
+    lines = open(filename, encoding="utf8").read().strip().split('\n')
     return [unicodeToAscii(line) for line in lines]
 
 # Build the category_lines dictionary, a list of lines per category


### PR DESCRIPTION
Not sure if only on my platform (win10 python 3.6), but couldn't run the char rnn classification without this fix