### PR TITLE
Update char-rnn-generation.ipynb

### DIFF
--- a/char-rnn-generation/char-rnn-generation.ipynb
+++ b/char-rnn-generation/char-rnn-generation.ipynb
@@ -341,12 +341,12 @@
     "\n",
     "    for c in range(chunk_len):\n",
     "        output, hidden = decoder(inp[c], hidden)\n",
-    "        loss += criterion(output, target[c])\n",
+    "        loss += criterion(output, target[c].unsqueeze(0)\n",
     "\n",
     "    loss.backward()\n",
     "    decoder_optimizer.step()\n",
     "\n",
-    "    return loss.data[0] / chunk_len"
+    "    return loss.data.item() / chunk_len"
    ]
   },
   {

--- a/char-rnn-generation/char-rnn-generation.ipynb
+++ b/char-rnn-generation/char-rnn-generation.ipynb
@@ -346,7 +346,7 @@
     "    loss.backward()\n",
     "    decoder_optimizer.step()\n",
     "\n",
-    "    return loss.data.item() / chunk_len"
+    "    return loss.item() / chunk_len"
    ]
   },
   {


### PR DESCRIPTION
Correction for error: "dimension specified as 0 but tensor has no dimensions" while starting training and does not train. This fix is specified on https://github.com/spro/practical-pytorch/issues/106 by user BlindElephants.


