### PR TITLE
X entropy loss input dimensions

### DIFF
--- a/char-rnn-generation/train.py
+++ b/char-rnn-generation/train.py
@@ -46,7 +46,7 @@ def train(inp, target):
 
     for c in range(args.chunk_len):
         output, hidden = decoder(inp[c], hidden)
-        loss += criterion(output, target[c])
+        loss += criterion(output, target[c].view([1]))
 
     loss.backward()
     decoder_optimizer.step()

--- a/char-rnn-generation/train.py
+++ b/char-rnn-generation/train.py
@@ -51,7 +51,7 @@ def train(inp, target):
     loss.backward()
     decoder_optimizer.step()
 
-    return loss.data[0] / args.chunk_len
+    return loss.data.item() / args.chunk_len
 
 def save():
     save_filename = os.path.splitext(os.path.basename(args.filename))[0] + '.pt'


### PR DESCRIPTION
`output`
gives `tensor([[-1.5800e-01, ...  1.1632e-01]], grad_fn=<AddmmBackward>)`
`target`
gives `tensor([10, 29, 14, 73, 96, 55, ..., 94])`
`target[c]`
gives `tensor(10)`

So `criterion(output, target[c])` gives `RuntimeError: dimension specified as 0 but tensor has no dimensions`. See PyTorch doc's about [CrossEntropyLoss](https://pytorch.org/docs/stable/nn.html?highlight=cross%20entropy#torch.nn.CrossEntropyLoss), it expects inputs of shape: "Input: (N,C) where C = number of classes" and "Target: (N)".

`target[c].view([1])`
gives `tensor([10])`, which fixes the error.

`return loss.data[0] / args.chunk_len` gives `IndexError: invalid index of a 0-dim tensor. Use tensor.item() to convert a 0-dim tensor to a Python number`.